### PR TITLE
ket's are not visible in the table

### DIFF
--- a/src/lib-components/ket-list-viewer.vue
+++ b/src/lib-components/ket-list-viewer.vue
@@ -15,40 +15,7 @@
         <td>
           <!-- VIEWER -->
           <div class="quantum-state-viewer">
-            <span
-              v-for="(ketComponent, index) in ketComponents"
-              :key="`ket-component-${index}`"
-              class="ket-component"
-            >
-              <span v-if="selectedStyle === 'polar'" class="ket-complex">
-                {{ renderComplexPolar(ketComponent.amplitude) }}
-              </span>
-              <span v-if="selectedStyle === 'cartesian'" class="ket-complex">
-                {{ renderComplexCartesian(ketComponent.amplitude) }}
-              </span>
-              <svg v-if="selectedStyle === 'color'" height="16" width="16" class="ket-disk">
-                <circle
-                  cx="8"
-                  cy="8"
-                  :r="discScale(ketComponent.amplitude.r)"
-                  :fill="complexToColor(ketComponent.amplitude)"
-                />
-              </svg>
-              <span
-                v-for="(particleCoord, pIndex) in ketComponent.particleCoords"
-                :key="`ket-component-${pIndex}`"
-                class="ket-coord"
-              >
-                | {{ particleCoord.x }},{{ particleCoord.y }}
-                <span class="ket-dir">
-                  {{ renderDir(particleCoord.dir) }}
-                </span>
-                <span class="ket-pol">
-                  {{ renderPol(particleCoord.pol) }}
-                </span>
-                ⟩
-              </span>
-            </span>
+            <ket-viewer :photons="state" :show-legend="false" :show-table="false"/>
           </div>
           <!-- VIEWER END -->
         </td>
@@ -59,50 +26,13 @@
         <td>
           <!-- VIEWER -->
           <div class="quantum-state-viewer">
-            <span
-              v-for="(ketComponent, index) in ketComponents"
-              :key="`ket-component-${index}`"
-              class="ket-component"
-            >
-              <span v-if="selectedStyle === 'polar'" class="ket-complex">
-                {{ renderComplexPolar(ketComponent.amplitude) }}
-              </span>
-              <span v-if="selectedStyle === 'cartesian'" class="ket-complex">
-                {{ renderComplexCartesian(ketComponent.amplitude) }}
-              </span>
-              <svg v-if="selectedStyle === 'color'" height="16" width="16" class="ket-disk">
-                <circle
-                  cx="8"
-                  cy="8"
-                  :r="discScale(ketComponent.amplitude.r)"
-                  :fill="complexToColor(ketComponent.amplitude)"
-                />
-              </svg>
-              <span
-                v-for="(particleCoord, pIndex) in ketComponent.particleCoords"
-                :key="`ket-component-${pIndex}`"
-                class="ket-coord"
-              >
-                | {{ particleCoord.x }},{{ particleCoord.y }}
-                <span class="ket-dir">
-                  {{ renderDir(particleCoord.dir) }}
-                </span>
-                <span class="ket-pol">
-                  {{ renderPol(particleCoord.pol) }}
-                </span>
-                ⟩
-              </span>
-            </span>
+            <ket-viewer :photons="state" :show-legend="false" :show-table="false"/>
           </div>
           <!-- VIEWER END -->
         </td>
       </tr>
     </tbody>
   </table>
-
-    <!-- <span class="hidebutton" @click="toggleKets"
-      >{{ ketHidden ? 'EXPAND' : 'COLLAPSE' }} SIMULATION INFO</span
-    > -->
     <!-- LEGEND -->
     <div v-if="showLegend && ketComponents.length > 0" class="legend-list">
       <coordinate-legend :selected-style="selectedStyle"/>
@@ -130,10 +60,10 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Complex, Photons, VectorEntry } from 'quantum-tensors';
 import { range } from '@/lib-components/utils';
-import { hslToHex, TAU } from '@/lib-components/colors';
 import CoordinateLegend from '@/lib-components/coordinate-legend.vue';
 import ViewerButton from '@/lib-components/viewer-button.vue';
 import ViewButtonGroup from '@/lib-components/view-button-group.vue';
+import KetViewer from '@/lib-components/ket-viewer.vue';
 
 // from interfaces.ts
 interface IParticleCoord {
@@ -181,6 +111,7 @@ const ketComponents = (photons: Photons, probThreshold = 1e-4): IKetComponent[] 
     CoordinateLegend,
     ViewerButton,
     ViewButtonGroup,
+    KetViewer,
   },
 })
 
@@ -201,43 +132,6 @@ export default class KetList extends Vue {
   toggleKets(): void {
     this.ketHidden = !this.ketHidden;
   }
-
-  toPercent(x: number, precision = 1): string {
-    return (100 * x).toFixed(precision);
-  }
-
-  //   elementName(x: number, y: number): string {
-  //     return x === -1 && y === -1 ? 'OutOfBoard' : this.grid.cellFromXY(x, y).element.name
-  //   }
-
-  renderComplexPolar(z: Complex, precision = 2): string {
-    return `${z.r.toFixed(precision)} exp(i${z.phi.toFixed(precision)})`;
-  }
-
-  renderComplexCartesian(z: Complex, precision = 2): string {
-    return `(${z.re.toFixed(precision)} + i${z.im.toFixed(precision)})`;
-  }
-
-  discScale(r: number): number {
-    return 8 * r;
-  }
-
-  complexToColor(z: Complex): string {
-    const angleInDegrees = ((z.arg() * 360) / TAU + 360) % 360;
-    return hslToHex(angleInDegrees, 100, 50);
-  }
-
-  renderDir(dir: number): string {
-    return ['→', '↑', '←', '↓'][dir];
-  }
-
-  renderPol(pol: number): string {
-    return ['H', 'V'][pol];
-  }
-
-  //   get absorptions(): IAbsorption[] {
-  //     return this.frame.absorptions
-  //   }
 
   get ketComponents(): IKetComponent[] {
     return ketComponents(this.photons);

--- a/src/serve-dev.vue
+++ b/src/serve-dev.vue
@@ -71,6 +71,7 @@ export default Vue.extend({
 <template>
   <div id="app">
     <ket-viewer :photons="state" />
+    <ket-viewer :photons="state" :show-legend="false" :show-table="false"/>
     <quantum-matrix
         :coord-names-in="coordNames"
         :coord-names-out="coordNames"


### PR DESCRIPTION
TO FIX
The photon state is not passed to the ket-viewer.vue element inside ket-list.viewer.vue.
![Screenshot 2020-01-30 at 12 44 40](https://user-images.githubusercontent.com/33489641/73448017-44e4fb00-4360-11ea-9767-35049f04c0d3.png)

But the ket-viewer.vue works well when inserted straight to the serve-dev.vue.
![Screenshot 2020-01-30 at 12 44 50](https://user-images.githubusercontent.com/33489641/73448092-6ba33180-4360-11ea-9943-2075be2bca8a.png)
