### PR TITLE
Ket element

### DIFF
--- a/src/lib-components/coordinate-legend.vue
+++ b/src/lib-components/coordinate-legend.vue
@@ -60,7 +60,7 @@ export default Vue.extend({
   font-family: 'Montserrat', Helvetica, Arial, sans-serif;
   text-transform: uppercase;
   & .legend-complex {
-    color: #9d40ff;
+    color: #d28fff;
     margin-right: 5px;
   }
   & .legend-dimension {

--- a/src/lib-components/ket-list-viewer.vue
+++ b/src/lib-components/ket-list-viewer.vue
@@ -178,7 +178,7 @@ td {
       display: flex;
       align-items: center;
       & .ket-complex {
-        color: #9d40ff;
+        color: #d28fff;
         padding: 0px 0px 0px 6px;
       }
       & .ket-disk {

--- a/src/lib-components/ket-list-viewer.vue
+++ b/src/lib-components/ket-list-viewer.vue
@@ -213,7 +213,7 @@ td {
     display: flex;
     justify-content: space-between;
     padding-top: 10px;
-    margin: 0px 10px;
+    margin: 0px 4px;
   }
   & .legend-list {
     margin: 0px 10px;

--- a/src/lib-components/ket-list-viewer.vue
+++ b/src/lib-components/ket-list-viewer.vue
@@ -23,11 +23,9 @@
           <td>{{ i }}</td>
           <td>{{ step.value }}</td>
           <td>
-            <ket-viewer
-              class="ket-viewer"
+            <ket
+              class="ket"
               :vector="step.vector"
-              :show-legend="false"
-              :show-table="false"
               :selected-option="selectedOption"
               :all-bases="allBases"
             />
@@ -77,13 +75,13 @@ import Vue from 'vue';
 import { Vector } from 'quantum-tensors';
 import CoordinateLegend from '@/lib-components/coordinate-legend.vue';
 import OptionsGroup from '@/lib-components/options-group.vue';
-import KetViewer from '@/lib-components/ket-viewer.vue';
+import Ket from '@/lib-components/ket.vue';
 
 export default Vue.extend({
   components: {
     CoordinateLegend,
     OptionsGroup,
-    KetViewer,
+    Ket,
   },
   props: {
     steps: {
@@ -152,7 +150,7 @@ td {
   & .hidebutton {
     font-size: 0.8rem;
   }
-  & .ket-viewer {
+  & .ket {
     font-weight: 500;
     display: flex;
     flex-wrap: wrap;

--- a/src/lib-components/ket-viewer.vue
+++ b/src/lib-components/ket-viewer.vue
@@ -219,7 +219,7 @@ export default Vue.extend({
       display: flex;
       align-items: center;
       & .ket-complex {
-        color: #9d40ff;
+        color: #d28fff;
         padding: 0px 0px 0px 6px;
       }
       & .ket-disk {

--- a/src/lib-components/ket.vue
+++ b/src/lib-components/ket.vue
@@ -1,0 +1,197 @@
+<template>
+  <div
+    ref="wrapper"
+    class="ket"
+  >
+    <div class="quantum-state-viewer">
+      <span
+        v-for="(ketComponent, index) in ketComponents"
+        :key="`ket-component-${index}`"
+        class="ket-component"
+      >
+        <span
+          v-if="selectedOptionFlexible !== 'color'"
+          class="ket-complex"
+        >
+          {{ ketComponent.amplitude.toString(selectedOptionFlexible) }}
+        </span>
+        <svg
+          v-if="selectedOptionFlexible === 'color'"
+          height="16"
+          width="16"
+          class="ket-disk"
+        >
+          <circle
+            cx="8"
+            cy="8"
+            :r="discScale(ketComponent.amplitude.r)"
+            :fill="complexToColor(ketComponent.amplitude)"
+          />
+        </svg>
+        <span class="ket-ket">
+          <span class="ket-parenthesis">|</span>
+          <span
+            v-for="(coordStr, i) in ketComponent.coordStrs"
+            :key="`ket-component-${i}-${coordStr}`"
+            class="ket-coord"
+            :style="{ color: dimensionNameToColor(dimensionNames[i]) }"
+          >{{ coordPrettier(coordStr) }}</span>
+          <span class="ket-parenthesis">⟩</span>
+        </span>
+      </span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import {
+  Dimension, Complex, Vector, VectorEntry, Basis,
+} from 'quantum-tensors';
+import { coordPrettier } from '@/lib-components/utils';
+import { hslToHex, TAU } from '@/lib-components/colors';
+
+interface IKetComponent {
+  amplitude: Complex;
+  coordStrs: string[];
+}
+
+interface IBasisSelector {
+    name: string;
+    availableBases: string[];
+    selected: string;
+}
+
+const allBasesDefault: IBasisSelector[] = [
+  { name: 'polarization', availableBases: ['HV', 'DA', 'LR'], selected: 'HV' },
+  { name: 'spin', availableBases: ['spin-x', 'spin-y', 'spin-z'], selected: 'spin-z' },
+  { name: 'qubit', availableBases: ['01', '+-', '+i-i'], selected: '01' },
+];
+
+export default Vue.extend({
+  props: {
+    vector: {
+      type: Object as () => Vector,
+      default: () => Vector.indicator([Dimension.qubit()], '0'),
+    },
+    selectedOption: {
+      type: String,
+      default: 'polar',
+    },
+    allBases: {
+      type: Array as () => IBasisSelector[],
+      default: () => allBasesDefault,
+    },
+  },
+  data() {
+    return {
+      options: ['polar', 'polarTau', 'cartesian', 'color'],
+      selectedOptionFlexible: this.selectedOption,
+    };
+  },
+  computed: {
+
+    dimensionNames(): string[] {
+      return this.vector.names;
+    },
+
+    ketComponents(): IKetComponent[] {
+      if (!this.vector) {
+        return [];
+      }
+      const probThreshold = 1e-4;
+      const basisPol = Basis.polarization(this.allBases.filter((d) => d.name === 'polarization')[0].selected);
+      const basisSpin = Basis.spin(this.allBases.filter((d) => d.name === 'spin')[0].selected);
+      const basisQubit = Basis.qubit(this.allBases.filter((d) => d.name === 'qubit')[0].selected);
+      const rotatedVector = basisQubit.changeAllDimsOfVector(
+        basisSpin.changeAllDimsOfVector(basisPol.changeAllDimsOfVector(this.vector)),
+      );
+      return rotatedVector.entries
+        .map((entry: VectorEntry): IKetComponent => ({
+          amplitude: entry.value,
+          coordStrs: entry.coord.map((c: number, dim: number) => rotatedVector.coordNames[dim][c]),
+        }))
+        .filter((d) => d.amplitude.r ** 2 > probThreshold);
+    },
+  },
+  methods: {
+
+    toPercent(x: number, precision = 1): string {
+      return (100 * x).toFixed(precision);
+    },
+
+    discScale(r: number): number {
+      return 8 * r;
+    },
+
+    complexToColor(z: Complex): string {
+      const angleInDegrees = ((z.arg() * 360) / TAU + 360) % 360;
+      return hslToHex(angleInDegrees, 100, 50);
+    },
+
+    coordPrettier(coord: string): string {
+      return coordPrettier(coord);
+    },
+
+    dimensionNameToColor(dimName: string): string {
+      switch (dimName) {
+        case 'direction':
+          return '#ff0055';
+        case 'polarization':
+          return '#ff9100';
+        case 'spin':
+          return '#0091ff';
+        default:
+          return '#ffffff';
+      }
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.ket {
+  padding-top: 10px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  transition: height 0.5s;
+  overflow: hidden;
+  align-content: space-between;
+  font-family: 'Montserrat', Helvetica, Arial, sans-serif;
+  & .quantum-state-viewer {
+    font-weight: 500;
+    display: flex;
+    flex-wrap: wrap;
+    & .ket-component {
+      background-color: rgba(0, 0, 0, 0.3);
+      margin: 5px;
+      line-height: 1.4rem;
+      font-size: 14px;
+      flex-wrap: nowrap;
+      flex-direction: row;
+      display: flex;
+      align-items: center;
+      & .ket-complex {
+        color: #d28fff;
+        padding: 0px 0px 0px 6px;
+      }
+      & .ket-disk {
+        margin-left: 5px;
+      }
+      & .ket-ket {
+        color: #fff;
+        padding: 0px 6px;
+        margin: 2px;
+        & .ket-parenthesis {
+          padding: 0px;
+        }
+        & .ket-coord {
+          padding: 2px;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/lib-components/ket.vue
+++ b/src/lib-components/ket.vue
@@ -10,13 +10,13 @@
         class="ket-component"
       >
         <span
-          v-if="selectedOptionFlexible !== 'color'"
+          v-if="selectedOption !== 'color'"
           class="ket-complex"
         >
-          {{ ketComponent.amplitude.toString(selectedOptionFlexible) }}
+          {{ ketComponent.amplitude.toString(selectedOption) }}
         </span>
         <svg
-          v-if="selectedOptionFlexible === 'color'"
+          v-if="selectedOption === 'color'"
           height="16"
           width="16"
           class="ket-disk"
@@ -83,12 +83,6 @@ export default Vue.extend({
       default: () => allBasesDefault,
     },
   },
-  data() {
-    return {
-      options: ['polar', 'polarTau', 'cartesian', 'color'],
-      selectedOptionFlexible: this.selectedOption,
-    };
-  },
   computed: {
 
     dimensionNames(): string[] {
@@ -151,11 +145,7 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 .ket {
-  padding-top: 10px;
-  width: 100%;
   display: flex;
-  flex-direction: column;
-  width: 100%;
   transition: height 0.5s;
   overflow: hidden;
   align-content: space-between;

--- a/src/lib-components/options-group.vue
+++ b/src/lib-components/options-group.vue
@@ -1,19 +1,17 @@
 <template>
   <div
     ref="wrapper"
-    class="view-button-group"
+    class="btn-group"
   >
-    <div class="btn-group">
-      <span
-        v-for="(option, index) in options"
-        :key="`option-${index}`"
-        class="button"
-        :class="{ selected: option === selectedOption }"
-        @click="$emit('selected', option)"
-      >
-        {{ option }}
-      </span>
-    </div>
+    <span
+      v-for="(option, index) in options"
+      :key="`option-${index}`"
+      class="button"
+      :class="{ selected: option === selectedOption }"
+      @click="$emit('selected', option)"
+    >
+      {{ option }}
+    </span>
   </div>
 </template>
 
@@ -37,9 +35,10 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .btn-group {
   display: flex;
-  justify-content: center;
-  max-width: 100%;
   margin-bottom: 5px;
+  overflow: hidden;
+  align-content: space-between;
+  flex-wrap: wrap;
 }
 
 .button {

--- a/src/lib-components/utils.ts
+++ b/src/lib-components/utils.ts
@@ -1,7 +1,10 @@
 export const range = (n: number): number[] => [...Array(n).keys()];
 
 export const coordPrettyMap = new Map<string, string>();
-const pairs: [string, string][] = [['>', '→'], ['^', '↑'], ['<', '←'], ['v', '↓']];
+const pairs: [string, string][] = [
+  ['>', '→'], ['^', '↑'], ['<', '←'], ['v', '↓'],
+  ['u', '↑z'], ['d', '↓z'], ['ux', '↑x'], ['dx', '↓x'], ['uy', '↑y'], ['dy', '↓y'],
+];
 pairs.forEach(([k, v]) => coordPrettyMap.set(k, v));
 
 export function coordPrettier(coord: string): string {

--- a/src/serve-dev.vue
+++ b/src/serve-dev.vue
@@ -5,6 +5,7 @@ import {
 } from 'quantum-tensors';
 import { KetViewer, MatrixViewer } from '@/entry';
 import KetList from './lib-components/ket-list-viewer.vue';
+import Ket from './lib-components/ket.vue';
 
 const sizeX = 8;
 const sizeY = 8;
@@ -58,6 +59,7 @@ export default Vue.extend({
     KetViewer,
     MatrixViewer,
     KetList,
+    Ket,
   },
   data() {
     return {
@@ -98,6 +100,8 @@ export default Vue.extend({
     <ket-viewer :vector="state.vector" />
     <h1>Ket Viewer for a singlet state</h1>
     <ket-viewer :vector="singlet" />
+    <h1>Ket</h1>
+    <ket :vector="singlet" />
     <h1>Ket List</h1>
     <ket-list :steps="steps" />
     <h1>Ket List Quantum Computing</h1>

--- a/src/serve-dev.vue
+++ b/src/serve-dev.vue
@@ -90,18 +90,12 @@ export default Vue.extend({
 
 <template>
   <div id="app">
+    <h1>Ket</h1>
+    <ket :vector="singlet" />
     <h1>Ket Viewer</h1>
-    <ket-viewer
-      :vector="state.vector"
-      :show-legend="false"
-      :show-table="false"
-    />
-    <h1>Ket Viewer + controls + legend</h1>
     <ket-viewer :vector="state.vector" />
     <h1>Ket Viewer for a singlet state</h1>
     <ket-viewer :vector="singlet" />
-    <h1>Ket</h1>
-    <ket :vector="singlet" />
     <h1>Ket List</h1>
     <ket-list :steps="steps" />
     <h1>Ket List Quantum Computing</h1>


### PR DESCRIPTION
New ket element, that is imported into ket-viewer and ket-list-viewer.
New spin notation with arrows instead of u/d.
Lighter (more visible) font color for ket.
![Screenshot 2020-02-24 at 15 40 04](https://user-images.githubusercontent.com/33489641/75161564-4c5bb200-571c-11ea-821e-9a2026106826.png)
![Screenshot 2020-02-24 at 15 40 26](https://user-images.githubusercontent.com/33489641/75161573-4e257580-571c-11ea-87a0-e9145d939169.png)
![Screenshot 2020-02-24 at 15 40 40](https://user-images.githubusercontent.com/33489641/75161576-4ebe0c00-571c-11ea-8f78-343585fd004a.png)


