### PR TITLE
Ket monospaced and other style changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2020-03-25
+
+Adjustments with Quantum Game in mind. See https://github.com/Quantum-Game/bra-ket-vue/pull/29.
+
+### Change
+
+- A more compact style for kets, including a monospace font and margin adjustments.
+
+### Fixed
+
+- SVG options now indicate the selected option.
+
 ## [0.2.2] - 2020-03-19
 
 ### Added
 
 - White style option, see https://github.com/Quantum-Game/bra-ket-vue/pull/27 for examples.
 - A screenshot for GitHub social preview.
+- Changelog!
 
 ## [0.2.1] - 2020-03-11
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Warning: it is an early alpha version. Everything can change (including core com
 
 * A NPM example in https://codesandbox.io/
 * A frontend JavaScript example in https://jsfiddle.net/ or https://codepen.io/
+    * https://jsfiddle.net/stared/1Lbuoxte/ - for the first example
 
 
 ## Notes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bra-ket-vue",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Interactive display of quantum states and operations, Vue components.",
   "contributors": [
     "Piotr Migdał",

--- a/src/lib-components/coordinate-legend.vue
+++ b/src/lib-components/coordinate-legend.vue
@@ -4,7 +4,7 @@
       :class="coordLegendClass(darkMode)"
     >
       <span v-if="complexStyle !== 'color'">
-        <span class="legend-complex">amplitude (complex number)</span>
+        <span class="legend-complex">amplitude</span>
       </span>
       <span>
         <span
@@ -81,6 +81,7 @@ export default Vue.extend({
 }
 
 .legend-dark {
+  display: inline;
   padding-top: 10px;
   padding-bottom: 10px;
   font-size: 10px;

--- a/src/lib-components/ket-viewer.vue
+++ b/src/lib-components/ket-viewer.vue
@@ -102,13 +102,17 @@ export default Vue.extend({
       type: Boolean,
       default: true,
     },
+    initialPolBasis: {
+      type: String,
+      default: 'HV',
+    },
   },
   data(): any {
     return {
       options: ['polar', 'polarTau', 'cartesian', 'color'],
       selectedOption: 'polar',
       allBases: [
-        { name: 'polarization', availableBases: ['HV', 'DA', 'LR'], selected: 'HV' },
+        { name: 'polarization', availableBases: ['HV', 'DA', 'LR'], selected: this.initialPolBasis },
         { name: 'spin', availableBases: ['spin-x', 'spin-y', 'spin-z'], selected: 'spin-z' },
         { name: 'qubit', availableBases: ['01', '+-', '+i-i'], selected: '01' },
       ],

--- a/src/lib-components/ket-viewer.vue
+++ b/src/lib-components/ket-viewer.vue
@@ -39,6 +39,38 @@
       :selected-option="selectedOption"
       @selected="selectedOption = $event"
     />
+
+    <span>
+      <span
+        v-for="bases in allBases"
+        :key="`basis-${bases.name}`"
+      >
+        <span
+          v-if="bases.name == 'polarization'"
+        >
+          <options-group-svg
+            v-if="dimensionNames.indexOf(bases.name) > -1"
+            :key="`options-group-basis-${bases.name}`"
+            :dark-mode="darkMode"
+            :options="bases.availableBases"
+            :selected-option="bases.selected"
+            @selected="bases.selected = $event"
+          />
+        </span>
+        <span
+          v-else
+        >
+          <options-group
+            v-if="dimensionNames.indexOf(bases.name) > -1"
+            :key="`options-group-basis-${bases.name}`"
+            :dark-mode="darkMode"
+            :options="bases.availableBases"
+            :selected-option="bases.selected"
+            @selected="bases.selected = $event"
+          />
+        </span>
+      </span>
+    </span>
   </div>
 </template>
 
@@ -47,12 +79,14 @@ import Vue from 'vue';
 import { Vector } from 'quantum-tensors';
 import CoordinateLegend from '@/lib-components/coordinate-legend.vue';
 import OptionsGroup from '@/lib-components/options-group.vue';
+import OptionsGroupSvg from '@/lib-components/options-group-svg.vue';
 import Ket from '@/lib-components/ket.vue';
 
 export default Vue.extend({
   components: {
     CoordinateLegend,
     OptionsGroup,
+    OptionsGroupSvg,
     Ket,
   },
   props: {

--- a/src/lib-components/ket.vue
+++ b/src/lib-components/ket.vue
@@ -197,6 +197,7 @@ export default Vue.extend({
         padding: 0px 0px 0px 6px;
       }
       & .ket-disk {
+        display: inline-flex;
         margin-left: 5px;
       }
       & .ket-ket {

--- a/src/lib-components/ket.vue
+++ b/src/lib-components/ket.vue
@@ -185,12 +185,12 @@ export default Vue.extend({
     font-size: 12px;
     & .ket-component-dark {
       background-color: rgba(0, 0, 0, 0.3);
-      margin: 5px 5px 5px 0px;
+      margin: 2px 5px 2px 0px;
       padding: 4px 0px;
       line-height: 1rem;
       flex-wrap: nowrap;
       flex-direction: row;
-      display: flex;
+      display: inline-block;
       align-items: center;
       & .ket-complex {
         color: #d28fff;

--- a/src/lib-components/ket.vue
+++ b/src/lib-components/ket.vue
@@ -178,7 +178,7 @@ export default Vue.extend({
   transition: height 0.5s;
   overflow: hidden;
   align-content: space-between;
-  font-family: 'Montserrat', Helvetica, Arial, sans-serif;
+  font-family: 'Consolas', monospace;
   & .quantum-state-viewer {
     display: flex;
     flex-wrap: wrap;

--- a/src/lib-components/matrix-labels.vue
+++ b/src/lib-components/matrix-labels.vue
@@ -190,6 +190,7 @@ export default Vue.extend({
     text-anchor: middle;
     fill: rgba(255, 255, 255, 0.5);
     cursor: default;
+    font-family: 'Consolas', monospace;
     font-weight: 300;
     &.selected {
       fill: rgba(255, 255, 255, 1);

--- a/src/lib-components/options-group-svg.vue
+++ b/src/lib-components/options-group-svg.vue
@@ -14,12 +14,12 @@
         class="base-change"
         :width="38"
         :height="19"
-        :class="buttonColor(darkMode)"
+        :class="buttonStyle(option)"
       >
         <g
           v-if="option == 'HV'"
           class="HV"
-          :style="{ fill: svgColor(darkMode)}"
+          :style="{ fill: svgColor}"
         >
           <polygon points="16.2,9 10.8,9 10.8,7 6.5,9.5 10.8,12 10.8,10 16.2,10 16.2,12 20.5,9.5 16.2,7" />
           <polygon points="29,6.3 31,6.3 28.5,2 26,6.3 28,6.3 28,12.7 26,12.7 28.5,17 31,12.7 29,12.7" />
@@ -27,7 +27,7 @@
         <g
           v-if="option == 'DA'"
           class="DA"
-          :style="{ fill: svgColor(darkMode)}"
+          :style="{ fill: svgColor}"
         >
           <polygon points="14.1,11.4 9.6,6.9 11,5.5 6.2,4.2 7.5,9 8.9,7.6 13.4,12.1 12,13.5 16.8,14.8 15.5,10" />
           <polygon points="30.5,9 31.8,4.2 27,5.5 28.4,6.9 23.9,11.4 22.5,10 21.2,14.8 26,13.5 24.6,12.1 29.1,7.6" />
@@ -35,7 +35,7 @@
         <g
           v-if="option == 'LR'"
           class="LR"
-          :style="{ fill: svgColor(darkMode)}"
+          :style="{ fill: svgColor}"
         >
           <path
             d="M10.4,2.9c-3.2,0-5.8,2.6-5.8,5.8h1c0-2.6,2.2-4.8,4.8-4.8c2.6,0,4.8,2.2,4.8,4.8c0,2.4-1.9,4.4-4.2,4.7,
@@ -69,18 +69,18 @@ export default Vue.extend({
       default: true,
     },
   },
-  methods: {
-    buttonColor(darkStyle = true): string {
-      if (darkStyle) {
-        return 'button-dark';
-      }
-      return 'button-bright';
+  computed: {
+    svgColor(): string {
+      return this.darkMode ? 'white' : '#242424';
     },
-    svgColor(darkStyle = true): string {
-      if (darkStyle) {
-        return 'white';
-      }
-      return '#242424';
+  },
+  methods: {
+    buttonStyle(option: string): Record<string, boolean> {
+      return {
+        'button-dark': this.darkMode,
+        'button-bright': !this.darkMode,
+        selected: option === this.selectedOption,
+      };
     },
   },
 });

--- a/src/lib-components/options-group.vue
+++ b/src/lib-components/options-group.vue
@@ -48,19 +48,13 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
-.btn-group-dark {
-  display: flex;
-  margin-bottom: 5px;
-  overflow: hidden;
-  align-content: space-between;
-  flex-wrap: wrap;
-}
 .button-dark {
+  display: inline-block;
   font-family: "Montserrat", Helvetica, Arial, sans-serif;
   background-color: rgba(255, 255, 255, 0.1);
   cursor: pointer;
   color: white;
-  padding: 4px 12px;
+  padding: 3px 8px;
   text-align: center;
   text-decoration: none;
   text-transform: uppercase;
@@ -75,11 +69,12 @@ export default Vue.extend({
   }
 }
 .button-bright {
+  display: inline-block;
   font-family: "Montserrat", Helvetica, Arial, sans-serif;
   background-color: rgba(168, 168, 168, 0.2);
   cursor: pointer;
   color: #242424;
-  padding: 4px 12px;
+  padding: 3px 8px;
   text-align: center;
   text-decoration: none;
   text-transform: uppercase;


### PR DESCRIPTION
See https://github.com/Quantum-Game/quantum-game-2/pull/174 for context.

* monospaced font for kets
* SVG basis change has not a selection indicator
* ket viewer has a basis selector
* smaller margins for ket components
* modified margins for options, so that it looks OK when in two lines
* coordinate legend margins and no "complex number"

And since "one screenshot is worth a thousand bullet points":

![image](https://user-images.githubusercontent.com/1001610/77557835-830f1e80-6eba-11ea-893e-869e814217b8.png)

