### PR TITLE
Kets for QG2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bra-ket-vue",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Interactive display of quantum states and operations, Vue components.",
   "contributors": [
     "Piotr Migdał",

--- a/src/lib-components/coordinate-legend.vue
+++ b/src/lib-components/coordinate-legend.vue
@@ -75,6 +75,8 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+@import "../style-variables.scss";
+
 .dim-label {
   color: white;
   padding: 5px;
@@ -85,7 +87,7 @@ export default Vue.extend({
   padding-top: 10px;
   padding-bottom: 10px;
   font-size: 10px;
-  font-family: 'Montserrat', Helvetica, Arial, sans-serif;
+  font-family: $mainFont;
   text-transform: uppercase;
   & .legend-complex {
     color: #d28fff;
@@ -100,7 +102,7 @@ export default Vue.extend({
   padding-top: 10px;
   padding-bottom: 10px;
   font-size: 10px;
-  font-family: 'Montserrat', Helvetica, Arial, sans-serif;
+  font-family: $mainFont;
   text-transform: uppercase;
   & .legend-complex {
     color: #7a06c7;

--- a/src/lib-components/ket-list-viewer.vue
+++ b/src/lib-components/ket-list-viewer.vue
@@ -168,6 +168,8 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+@import "../style-variables.scss";
+
 .table-dark {
   font-size: 12px;
   font-weight: 300;
@@ -209,7 +211,7 @@ th {
   transition: height 0.5s;
   overflow: hidden;
   align-content: space-between;
-  font-family: 'Montserrat', Helvetica, Arial, sans-serif;
+  font-family: $mainFont;
   & .hidebutton {
     font-size: 0.8rem;
   }

--- a/src/lib-components/ket-viewer.vue
+++ b/src/lib-components/ket-viewer.vue
@@ -127,6 +127,8 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+@import "../style-variables.scss";
+
 .ket-viewer {
   width: 100%;
   display: flex;
@@ -135,7 +137,7 @@ export default Vue.extend({
   align-items: center;
   transition: height 0.5s;
   overflow: hidden;
-  font-family: 'Montserrat', Helvetica, Arial, sans-serif;
+  font-family: $mainFont;
   @media screen and (max-width: 1000px) {
     border: none;
   }

--- a/src/lib-components/ket.vue
+++ b/src/lib-components/ket.vue
@@ -174,12 +174,14 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+@import "../style-variables.scss";
+
 .ket {
   display: flex;
   transition: height 0.5s;
   overflow: hidden;
   align-content: space-between;
-  font-family: 'Consolas', monospace;
+  font-family: $ketFont;
   & .quantum-state-viewer {
     display: flex;
     flex-wrap: wrap;

--- a/src/lib-components/ket.vue
+++ b/src/lib-components/ket.vue
@@ -19,8 +19,9 @@
         </span>
         <svg
           v-if="selectedOption === 'color'"
-          height="16"
-          width="16"
+          height="100%"
+          width="100%"
+          viewBox="0 0 16 16"
           class="ket-disk"
         >
           <circle
@@ -189,16 +190,13 @@ export default Vue.extend({
       padding: 3px 4px;
       flex-wrap: nowrap;
       flex-direction: row;
-      display: inline-block;
+      display: flex;
       align-items: center;
       & .ket-complex {
         color: #d28fff;
         margin-right: 2px;
       }
-      & .ket-disk {
-        display: inline-flex;
-        margin-left: 5px;
-      }
+
       & .ket-coords {
         display: inline-flex;
         color: #fff;
@@ -232,9 +230,6 @@ export default Vue.extend({
         padding-right: 3px;
         color: #242424;
       }
-    }
-    & .ket-disk {
-      margin-left: 5px;
     }
     & .ket-parenthesis {
       padding: 0px;

--- a/src/lib-components/ket.vue
+++ b/src/lib-components/ket.vue
@@ -106,14 +106,15 @@ export default Vue.extend({
         selectedBasis[basis.name] = basis.selected;
       });
 
-      return this.vector
+      const vectorRotated = this.vector
         .toBasisAll('polarization', selectedBasis.polarization)
         .toBasisAll('spin', selectedBasis.spin)
-        .toBasisAll('qubit', selectedBasis.qubit)
-        .entries
+        .toBasisAll('qubit', selectedBasis.qubit);
+
+      return vectorRotated.entries
         .map((entry: VectorEntry): IKetComponent => ({
           amplitude: entry.value,
-          coordStrs: entry.coord.map((c: number, dim: number) => this.vector.coordNames[dim][c]),
+          coordStrs: entry.coord.map((c: number, dim: number) => vectorRotated.coordNames[dim][c]),
         }))
         .filter((d) => d.amplitude.r ** 2 > probThreshold);
     },

--- a/src/lib-components/ket.vue
+++ b/src/lib-components/ket.vue
@@ -30,7 +30,7 @@
             :fill="complexToColor(ketComponent.amplitude)"
           />
         </svg>
-        <span class="ket-ket">
+        <span class="ket-coords">
           <span class="ket-parenthesis">|</span>
           <span
             v-for="(coordStr, i) in ketComponent.coordStrs"
@@ -185,28 +185,27 @@ export default Vue.extend({
     font-size: 12px;
     & .ket-component-dark {
       background-color: rgba(0, 0, 0, 0.3);
-      margin: 2px 5px 2px 0px;
-      padding: 4px 0px;
-      line-height: 1rem;
+      margin: 2px 6px 0px 0px;
+      padding: 3px 4px;
       flex-wrap: nowrap;
       flex-direction: row;
       display: inline-block;
       align-items: center;
       & .ket-complex {
         color: #d28fff;
-        padding: 0px 0px 0px 6px;
+        margin-right: 2px;
       }
       & .ket-disk {
         display: inline-flex;
         margin-left: 5px;
       }
-      & .ket-ket {
+      & .ket-coords {
+        display: inline-flex;
         color: #fff;
-        padding: 0px 3px;
-        margin: 2px;
       }
       & .ket-coord {
-        padding: 2px;
+        padding-right: 1px;
+        padding-right: 3px;
       }
     }
     & .ket-component-bright {
@@ -214,24 +213,23 @@ export default Vue.extend({
       border-style: solid;
       border-color: rgb(240, 240, 240);
       background-color: white;
-      margin: 5px 5px 5px 0px;
-      padding: 4px 0px;
-      line-height: 1rem;
+      margin: 2px 6px 0px 0px;
+      padding: 3px 4px;
       flex-wrap: nowrap;
       flex-direction: row;
       display: flex;
       align-items: center;
       & .ket-complex {
         color: #7a06c7;
-        padding: 0px 0px 0px 6px;
+        margin-right: 2px;
       }
-      & .ket-ket {
+      & .ket-coords {
+        display: inline-flex;
         color: #242424;
-        padding: 0px 3px;
-        margin: 2px;
       }
       & .ket-coord {
-        padding: 2px;
+        padding-right: 1px;
+        padding-right: 3px;
         color: #242424;
       }
     }

--- a/src/lib-components/matrix-dimensions.vue
+++ b/src/lib-components/matrix-dimensions.vue
@@ -118,6 +118,8 @@ export default Vue.extend({
 </script>
 
 <style scoped lang="scss">
+@import "../style-variables.scss";
+
 .dimension-labels-dark {
   & .dimension-label {
     font-size: 12px;

--- a/src/lib-components/matrix-labels.vue
+++ b/src/lib-components/matrix-labels.vue
@@ -183,6 +183,8 @@ export default Vue.extend({
 </script>
 
 <style scoped lang="scss">
+@import "../style-variables.scss";
+
 .matrix-labels-dark{
   & text.coord {
     font-size: 16px;
@@ -190,7 +192,7 @@ export default Vue.extend({
     text-anchor: middle;
     fill: rgba(255, 255, 255, 0.5);
     cursor: default;
-    font-family: 'Consolas', monospace;
+    font-family: $ketFont;
     font-weight: 300;
     &.selected {
       fill: rgba(255, 255, 255, 1);

--- a/src/lib-components/matrix-viewer.vue
+++ b/src/lib-components/matrix-viewer.vue
@@ -291,9 +291,11 @@ export default Vue.extend({
 </script>
 
 <style scoped lang="scss">
+@import "../style-variables.scss";
+
 .matrix-viewer {
   display: flex;
-  font-family: 'Montserrat', Helvetica, Arial, sans-serif;
+  font-family: $mainFont;
 }
 .legend-container-dark {
   //display: block;

--- a/src/lib-components/options-group-svg.vue
+++ b/src/lib-components/options-group-svg.vue
@@ -87,6 +87,8 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+@import "../style-variables.scss";
+
 .btn-group {
   display: flex;
   margin-bottom: 5px;
@@ -95,7 +97,7 @@ export default Vue.extend({
   flex-wrap: wrap;
 }
 .button {
-  font-family: 'Montserrat', Helvetica, Arial, sans-serif;
+  font-family: $mainFont;
   cursor: pointer;
   text-align: center;
   text-decoration: none;

--- a/src/lib-components/options-group.vue
+++ b/src/lib-components/options-group.vue
@@ -48,9 +48,11 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+@import "../style-variables.scss";
+
 .button-dark {
   display: inline-block;
-  font-family: "Montserrat", Helvetica, Arial, sans-serif;
+  font-family: $mainFont;
   background-color: rgba(255, 255, 255, 0.1);
   cursor: pointer;
   color: white;
@@ -70,7 +72,7 @@ export default Vue.extend({
 }
 .button-bright {
   display: inline-block;
-  font-family: "Montserrat", Helvetica, Arial, sans-serif;
+  font-family: $mainFont;
   background-color: rgba(168, 168, 168, 0.2);
   cursor: pointer;
   color: #242424;

--- a/src/serve-dev.vue
+++ b/src/serve-dev.vue
@@ -151,6 +151,8 @@ export default Vue.extend({
 </template>
 
 <style lang="scss" scoped>
+@import "./style-variables.scss";
+
 #app {
   // background-color: rgb(255, 255, 255);
   background-color: #242424; //GREY
@@ -190,7 +192,7 @@ export default Vue.extend({
   padding: 30px;
 }
 h1 {
-  font-family: 'Montserrat', Helvetica, Arial, sans-serif;
+  font-family: $mainFont;
   color: rgba(255, 255, 255, 0.6);
   text-align: left;
   text-decoration: none;

--- a/src/style-variables.scss
+++ b/src/style-variables.scss
@@ -1,0 +1,2 @@
+$mainFont: 'Montserrat', Helvetica, Arial, sans-serif;
+$ketFont: 'Consolas', monospace;


### PR DESCRIPTION
Made fonts more compact, and changed styles so it *should* (I hope) work in the same way with the Quantum Game  (https://github.com/Quantum-Game/quantum-game-2/pull/174), I hope so. 

![image](https://user-images.githubusercontent.com/1001610/77807521-5f013800-7088-11ea-89de-1d5a3775dcba.png)

Also, I try to refactor some code, especially setting variables (e.g. for fonts) so to avoid repetition:

* https://sass-lang.com/guide
* https://css-tricks.com/how-to-import-a-sass-file-into-every-vue-component-in-an-app/ -> works for `serve`, but not `build`

There are challenges, though:

* https://github.com/vuejs/rollup-plugin-vue/issues/300

I did the simple way, importing `style-variables.scss` everywhere, manually. @KlemKlem - it may help you defining main colors, fonts and other choices in one place.

Working on something with coord names not changing with basis chance.