### PR TITLE
Make ket-viewer and matrix-viewer reactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Each `vector` is a `Vector` object from Quantum Tensors, and each `operator` is 
 ### Operators (matrices)
 
 ```{html}
-<matrix-viewer :operator-raw="operator" :dark-mode="true" />
+<matrix-viewer :operator="operator" :dark-mode="true" />
 ```
 
 ![Matrix - beam-splitter](imgs/beam_splitter.png)

--- a/src/lib-components/ket-viewer.vue
+++ b/src/lib-components/ket-viewer.vue
@@ -61,7 +61,14 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import {
+  computed,
+  defineComponent,
+  PropType,
+  proxyRefs,
+  ref,
+  watch,
+} from 'vue';
 import { Vector } from 'quantum-tensors';
 import CoordinateLegend from '@/lib-components/coordinate-legend.vue';
 import OptionsGroup from '@/lib-components/options-group.vue';
@@ -77,38 +84,27 @@ export default defineComponent({
     Ket,
   },
   props: {
-    vector: {
-      type: Object as () => Vector,
-      required: true,
-    },
-    showLegend: {
-      type: Boolean,
-      default: true,
-    },
-    darkMode: {
-      type: Boolean,
-      default: true,
-    },
-    initialPolBasis: {
-      type: String,
-      default: 'HV',
-    },
+    vector: { type: Object as PropType<Vector>, required: true },
+    showLegend: { type: Boolean, default: true },
+    darkMode: { type: Boolean, default: true },
+    polBasis: { type: String, default: 'HV' },
   },
-  data() {
+  setup(props) {
+    const innerPolBasis = ref(props.polBasis);
+    watch(() => props.polBasis, (basis) => {
+      innerPolBasis.value = basis;
+    });
+
     return {
+      dimensionNames: computed(() => props.vector.names),
       options: ['polar', 'polarTau', 'cartesian', 'color'],
       selectedOption: 'polar',
       allBases: [
-        { name: 'polarization', availableBases: ['HV', 'DA', 'LR'], selected: this.initialPolBasis },
+        proxyRefs({ name: 'polarization', availableBases: ['HV', 'DA', 'LR'], selected: innerPolBasis }),
         { name: 'spin', availableBases: ['spin-x', 'spin-y', 'spin-z'], selected: 'spin-z' },
         { name: 'qubit', availableBases: ['01', '+-', '+i-i'], selected: '01' },
       ],
     };
-  },
-  computed: {
-    dimensionNames(): string[] {
-      return this.vector.names;
-    },
   },
 });
 </script>

--- a/src/lib-components/ket.vue
+++ b/src/lib-components/ket.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, PropType } from 'vue';
 import {
   Dimension, Complex, Vector, interfaces,
 } from 'quantum-tensors';
@@ -65,7 +65,7 @@ export default defineComponent({
   name: 'Ket',
   props: {
     vector: {
-      type: Object as () => Vector,
+      type: Object as PropType<Vector>,
       default: () => Vector.indicator([Dimension.qubit()], '0'),
     },
     selectedOption: {
@@ -73,7 +73,7 @@ export default defineComponent({
       default: 'polar',
     },
     allBases: {
-      type: Array as () => IBasisSelector[],
+      type: Array as PropType<IBasisSelector[]>,
       default: () => allBasesDefault,
     },
     darkMode: {

--- a/src/lib-components/matrix-dimensions.vue
+++ b/src/lib-components/matrix-dimensions.vue
@@ -29,7 +29,6 @@ import { range } from '@/lib-components/utils';
 
 export default defineComponent({
   name: 'MatrixDimensions',
-  emits: ['swap-dimensions'],
   props: {
     size: {
       type: Number,
@@ -48,6 +47,7 @@ export default defineComponent({
       default: true,
     },
   },
+  emits: ['swap-dimensions'],
   computed: {
     swaps(): number[] {
       return range(this.dimensionNamesNumbered.length - 1);

--- a/src/lib-components/matrix-viewer.vue
+++ b/src/lib-components/matrix-viewer.vue
@@ -128,6 +128,7 @@ import {
   defineComponent,
   PropType,
   ref,
+  watch,
 } from 'vue';
 import {
   Vector, VectorEntry, Operator, helpers, Cx, Dimension,
@@ -186,6 +187,13 @@ export default defineComponent({
     ]);
 
     const permuteOrder = ref(range(props.operator.dimensionsOut.length));
+
+    watch(() => props.operator.dimensionsOut.length, (len) => {
+      if (len !== permuteOrder.value.length) {
+        permuteOrder.value = range(props.operator.dimensionsOut.length);
+      }
+    });
+
     const innerOperator = computed(() => {
       const op = props.operator;
       const permuteBoth = (op.dimensionsOut.length === op.dimensionsIn.length)

--- a/src/lib-components/matrix-viewer.vue
+++ b/src/lib-components/matrix-viewer.vue
@@ -82,7 +82,7 @@
           change basis
         </div>
         <div
-          v-for="(index, bases) in allBases"
+          v-for="(bases, index) in allBases"
           :key="`basis-${bases.name}`"
         >
           <span
@@ -94,7 +94,7 @@
               :options="bases.availableBases"
               :dark-mode="darkMode"
               :selected-option="bases.selected"
-              @selected="changeBasis(bases, $event)"
+              @selected="changeBasis(index, $event)"
             />
           </span>
           <span

--- a/src/lib-components/matrix-viewer.vue
+++ b/src/lib-components/matrix-viewer.vue
@@ -328,8 +328,9 @@ export default defineComponent({
      */
     function swapDimensions(i: number): void {
       const newOrder = [...permuteOrder.value];
-      newOrder[i] += 1;
-      newOrder[i + 1] -= 1;
+      const swap = newOrder[i + 1];
+      newOrder[i + 1] = newOrder[i];
+      newOrder[i] = swap;
       permuteOrder.value = newOrder;
     }
 

--- a/src/lib-components/matrix-viewer.vue
+++ b/src/lib-components/matrix-viewer.vue
@@ -53,7 +53,7 @@
             :height="rowSize"
           />
           <rect
-            v-if="selectedEntry.j > -1"
+            v-if="selectedEntry"
             class="selected-column"
             :x="scale(selectedEntry.j)"
             :y="0"
@@ -82,7 +82,7 @@
           change basis
         </div>
         <div
-          v-for="bases in allBases"
+          v-for="(index, bases) in allBases"
           :key="`basis-${bases.name}`"
         >
           <span
@@ -106,7 +106,7 @@
               :options="bases.availableBases"
               :dark-mode="darkMode"
               :selected-option="bases.selected"
-              @selected="changeBasis(bases, $event)"
+              @selected="changeBasis(index, $event)"
             />
           </span>
         </div>
@@ -123,9 +123,14 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
 import {
-  Vector, VectorEntry, Operator, helpers, Cx,
+  computed,
+  defineComponent,
+  PropType,
+  ref,
+} from 'vue';
+import {
+  Vector, VectorEntry, Operator, helpers, Cx, Dimension,
 } from 'quantum-tensors';
 import { colorComplexPhaseToHue } from '@/lib-components/colors';
 import { range } from '@/lib-components/utils';
@@ -140,12 +145,6 @@ interface IMatrixElement {
   j: number
   re: number
   im: number
-}
-
-interface IBases {
-  name: string
-  availableBases: string[]
-  selected: string
 }
 
 /**
@@ -172,170 +171,195 @@ export default defineComponent({
     OptionsGroupSvg,
     ComplexLegend,
   },
-  emits: ['column-mouseover'],
   props: {
-    size: {
-      type: Number,
-      default: 40,
-    },
-    operatorRaw: {
-      type: Object as () => Operator,
-      required: true,
-    },
-    darkMode: {
-      type: Boolean,
-      default: true,
-    },
-    showLegend: {
-      type: Boolean,
-      default: true,
-    },
+    size: { type: Number, default: 40 },
+    operator: { type: Object as PropType<Operator>, required: true },
+    darkMode: { type: Boolean, default: true },
+    showLegend: { type: Boolean, default: true },
   },
-  data(): {
-    operator: Operator, allBases: IBases[], selectedEntry: IMatrixElement, dimensionNamesOutNumbered: string[]
-    } {
-    return {
-      operator: this.operatorRaw,
-      allBases: [
-        { name: 'polarization', availableBases: ['HV', 'DA', 'LR'], selected: 'HV' },
-        { name: 'spin', availableBases: ['spin-x', 'spin-y', 'spin-z'], selected: 'spin-z' },
-        { name: 'qubit', availableBases: ['01', '+-', '+i-i'], selected: '01' },
-      ],
-      selectedEntry: {
-        i: -1, j: -1, re: 0, im: 0,
-      },
-      dimensionNamesOutNumbered: numberDimNames(this.operatorRaw.namesOut),
+  emits: ['column-mouseover'],
+  setup(props, { emit }) {
+    const allBases = ref([
+      { name: 'polarization', availableBases: ['HV', 'DA', 'LR'], selected: 'HV' },
+      { name: 'spin', availableBases: ['spin-x', 'spin-y', 'spin-z'], selected: 'spin-z' },
+      { name: 'qubit', availableBases: ['01', '+-', '+i-i'], selected: '01' },
+    ]);
+
+    const permuteOrder = ref(range(props.operator.dimensionsOut.length));
+    const innerOperator = computed(() => {
+      const op = props.operator;
+      const permuteBoth = (op.dimensionsOut.length === op.dimensionsIn.length)
+        && op.dimensionsOut
+          .every((d, di) => d.isEqual(op.dimensionsIn[di]));
+
+      const permuted = permuteBoth ? op.permute(permuteOrder.value) : op.permuteDimsOut(permuteOrder.value);
+      const bases = allBases.value;
+      return permuted
+        .toBasisAll('polarization', bases[0].selected)
+        .toBasisAll('spin', bases[1].selected)
+        .toBasisAll('qubit', bases[2].selected);
+    });
+
+    type AbsoluteCoord = Record<string, number>
+
+    function fromAbsoluteCoord(coord: AbsoluteCoord, dims: Dimension[]): number | null {
+      if (Object.entries(coord).length !== dims.length) return null;
+      const out = dims.map((dim) => coord[dim.name]);
+      if (out.some((n) => n == null)) return null;
+      return helpers.coordsToIndex(out, dims.map((d) => d.size));
+    }
+
+    function toAbsoluteCoord(idx: number, dims: Dimension[]): AbsoluteCoord {
+      const coord = helpers.coordsFromIndex(idx, dims.map((d) => d.size));
+      const abs: AbsoluteCoord = {};
+      for (let i = 0; i < coord.length; i += 1) {
+        abs[dims[i].name] = coord[i];
+      }
+      return abs;
+    }
+
+    const selection = ref<[AbsoluteCoord, AbsoluteCoord] | null>(null);
+
+
+    const matrixElements = computed((): IMatrixElement[] => innerOperator.value
+      .toIndexIndexValues()
+      .map((entry) => ({
+        i: entry.i,
+        j: entry.j,
+        re: entry.v.re,
+        im: entry.v.im,
+      })));
+
+    const defaultEntry = {
+      i: -1,
+      j: -1,
+      re: 0,
+      im: 0,
     };
-  },
-  computed: {
-    matrixElements(): IMatrixElement[] {
-      return this.operator
-        .toIndexIndexValues()
-        .map((entry) => ({
-          i: entry.i,
-          j: entry.j,
-          re: entry.v.re,
-          im: entry.v.im,
-        }));
-    },
 
-    coordNamesIn(): string[][] {
-      return this.operator.coordNamesIn;
-    },
+    const selectedEntry = computed((): IMatrixElement => {
+      const op = innerOperator.value;
+      if (selection.value == null) return defaultEntry;
 
-    coordNamesOut(): string[][] {
-      return this.operator.coordNamesOut;
-    },
+      const [absCoordOut, absCoordIn] = selection.value;
+      const coordOut = fromAbsoluteCoord(absCoordOut, op.dimensionsOut);
+      const coordIn = fromAbsoluteCoord(absCoordIn, op.dimensionsIn);
+      if (coordIn == null || coordOut == null) return defaultEntry;
+      return matrixElements.value.find(({ i, j }) => i === coordOut && j === coordIn)
+        || {
+          i: coordOut, j: coordIn, re: 0, im: 0,
+        };
+    });
 
-    dimensionNamesOut(): string[] {
-      return this.operator.dimensionsOut.map((dim) => dim.name);
-    },
+    const coordNamesIn = computed(() => innerOperator.value.coordNamesIn);
 
-    selectedIn(): number[] {
-      return [this.selectedEntry.j];
-    },
+    const coordNamesOut = computed(() => innerOperator.value.coordNamesOut);
 
-    selectedOut(): number[] {
-      return this.matrixElements
-        .filter((d) => d.j === this.selectedEntry.j)
+    const dimensionNamesOut = computed(() => innerOperator.value.dimensionsOut.map((dim) => dim.name));
+
+    const selectedIn = computed((): number[] => {
+      if (selectedEntry.value == null) return [];
+      return [selectedEntry.value.j];
+    });
+
+    const selectedOut = computed((): number[] => {
+      if (selectedEntry.value == null) return [];
+      const { j } = selectedEntry.value;
+      return matrixElements.value
+        .filter((d) => d.j === j)
         .map((d) => d.i);
-    },
+    });
 
     /**
      * Width
      */
-    columnSize(): number {
-      return this.size * this.operator.totalSizeIn;
-    },
+    const columnSize = computed((): number => props.size * innerOperator.value.totalSizeIn);
 
     /**
      * Height
      */
-    rowSize(): number {
-      return this.size * this.operator.totalSizeOut;
-    },
+    const rowSize = computed((): number => props.size * innerOperator.value.totalSizeOut);
 
-    allTileLocations(): { i: number; j: number }[] {
-      return range(this.operator.totalSizeOut)
-        .flatMap((i) => range(this.operator.totalSizeIn).map((j) => ({
-          i, j, re: 0, im: 0,
-        })));
-    },
+    const allTileLocations = computed((): { i: number; j: number }[] => range(innerOperator.value.totalSizeOut)
+      .flatMap((i) => range(innerOperator.value.totalSizeIn).map((j) => ({
+        i, j, re: 0, im: 0,
+      }))));
 
-    legendContainer(): string {
-      return this.darkMode ? 'legend-container-dark' : 'legend-container-bright';
-    },
+    const legendContainer = computed((): string => (
+      props.darkMode
+        ? 'legend-container-dark'
+        : 'legend-container-bright'));
 
-    quantumMatrixClass(): string {
-      return this.darkMode ? 'quantum-matrix-dark' : 'quantum-matrix-bright';
-    },
-  },
-  methods: {
-    scale(i: number): number {
-      return i * this.size;
-    },
+    const quantumMatrixClass = computed((): string => (
+      props.darkMode
+        ? 'quantum-matrix-dark'
+        : 'quantum-matrix-bright'));
 
-    generateColor(re: number, im: number): string {
+    const dimensionNamesOutNumbered = computed(() => numberDimNames(innerOperator.value.namesOut));
+
+    function scale(i: number): number {
+      return i * props.size;
+    }
+
+    function generateColor(re: number, im: number): string {
       return colorComplexPhaseToHue(re, im, 100, 50);
-    },
+    }
 
-    rScale(re: number, im = 0): number {
-      return 0.46 * this.size * Math.sqrt(re ** 2 + im ** 2);
-    },
+    function rScale(re: number, im = 0): number {
+      return 0.46 * props.size * Math.sqrt(re ** 2 + im ** 2);
+    }
 
     /**
      * Emit unit vector for input
      */
-    tileMouseOver(tile: IMatrixElement): void {
-      this.selectedEntry = tile;
-      const coords = helpers.coordsFromIndex(tile.j, this.operator.sizeIn);
-      const vec = new Vector([new VectorEntry(coords, Cx(1))], [...this.operator.dimensionsIn]);
-      this.$emit('column-mouseover', vec);
-    },
+    function tileMouseOver(tile: IMatrixElement): void {
+      const coordOut = toAbsoluteCoord(tile.i, innerOperator.value.dimensionsOut);
+      const coordIn = toAbsoluteCoord(tile.j, innerOperator.value.dimensionsIn);
+      selection.value = [coordOut, coordIn];
+
+      const coords = helpers.coordsFromIndex(tile.j, innerOperator.value.sizeIn);
+      const vec = new Vector([new VectorEntry(coords, Cx(1))], [...innerOperator.value.dimensionsIn]);
+      emit('column-mouseover', vec);
+    }
 
     /**
      * @todo Make all dimension changes within this component.
      * (After using Operator rather than passed parameteres.)
      */
-    swapDimensions(i: number): void {
-      const both = (this.operatorRaw.dimensionsOut.length === this.operatorRaw.dimensionsIn.length)
-        && this.operatorRaw.dimensionsOut
-          .map((d, di) => d.isEqual(this.operatorRaw.dimensionsIn[di]))
-          .reduce((a, b) => a && b, true);
-      const newOrder = range(this.operator.dimensionsOut.length);
+    function swapDimensions(i: number): void {
+      const newOrder = [...permuteOrder.value];
       newOrder[i] += 1;
       newOrder[i + 1] -= 1;
-      if (both) {
-        if (this.selectedEntry.j >= 0) {
-          const oldSelectedCoords = helpers.coordsFromIndex(this.selectedEntry.j, this.operator.sizeIn);
-          this.operator = this.operator.permute(newOrder);
-          const newSelectedCoords = range(this.operator.dimensionsIn.length).map((k) => oldSelectedCoords[newOrder[k]]);
-          this.selectedEntry.j = helpers.coordsToIndex(newSelectedCoords, this.operator.sizeIn);
-        } else {
-          this.operator = this.operator.permute(newOrder);
-        }
-      } else {
-        // console.log('perm out', newOrder);
-        // console.log('perm in', range(this.operator.dimensionsIn.length));
-        this.operator = this.operator.permuteDimsOut(newOrder);
-      }
+      permuteOrder.value = newOrder;
+    }
 
-      // for labels
-      const a = this.dimensionNamesOutNumbered[i];
-      const b = this.dimensionNamesOutNumbered[i + 1];
-      this.dimensionNamesOutNumbered[i] = b;
-      this.dimensionNamesOutNumbered[i + 1] = a;
-    },
+    function changeBasis(index: number, basis: string) {
+      allBases.value[index].selected = basis;
+    }
 
-    changeBasis(bases: IBases, basis: string) {
-      // eslint-disable-next-line no-param-reassign
-      bases.selected = basis;
-      this.selectedEntry = {
-        i: -1, j: -1, re: 0, im: 0,
-      };
-      this.operator = this.operator.toBasisAll(bases.name, basis);
-    },
-
+    return {
+      allBases,
+      innerOperator,
+      selectedEntry,
+      matrixElements,
+      coordNamesIn,
+      coordNamesOut,
+      dimensionNamesOut,
+      selectedIn,
+      selectedOut,
+      columnSize,
+      rowSize,
+      allTileLocations,
+      legendContainer,
+      quantumMatrixClass,
+      dimensionNamesOutNumbered,
+      scale,
+      generateColor,
+      rScale,
+      tileMouseOver,
+      swapDimensions,
+      changeBasis,
+    };
   },
 });
 </script>

--- a/src/lib-components/options-group-svg.vue
+++ b/src/lib-components/options-group-svg.vue
@@ -56,7 +56,6 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'OptionsGroupSvg',
-  emits: ['selected'],
   props: {
     selectedOption: {
       type: String,
@@ -71,6 +70,7 @@ export default defineComponent({
       default: true,
     },
   },
+  emits: ['selected'],
   computed: {
     svgColor(): string {
       return this.darkMode ? 'white' : '#242424';

--- a/src/lib-components/options-group.vue
+++ b/src/lib-components/options-group.vue
@@ -19,7 +19,6 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'OptionsGroup',
-  emits: ['selected'],
   props: {
     selectedOption: {
       type: String,
@@ -34,6 +33,7 @@ export default defineComponent({
       default: true,
     },
   },
+  emits: ['selected'],
   methods: {
     buttonStyle(option: string): Record<string, boolean> {
       return {

--- a/src/serve-dev.vue
+++ b/src/serve-dev.vue
@@ -112,10 +112,10 @@ export default defineComponent({
 
 <template>
   <h1>AND</h1>
-  <matrix-viewer :operator-raw="opAnd" />
+  <matrix-viewer :operator="opAnd" />
   <h1>COPY</h1>
   <matrix-viewer
-    :operator-raw="opCopy"
+    :operator="opCopy"
     :show-legend="false"
   />
   <h1>Ket</h1>
@@ -161,24 +161,24 @@ export default defineComponent({
   <div class="bright">
     <h1>beamSplitter 50/50</h1>
     <matrix-viewer
-      :operator-raw="operator"
+      :operator="operator"
       :dark-mode="false"
     />
   </div>
   <h1>beamSplitter 50/50</h1>
-  <matrix-viewer :operator-raw="operator" />
+  <matrix-viewer :operator="operator" />
   <h1>Pauli Z operator for spin</h1>
-  <matrix-viewer :operator-raw="operator2" />
+  <matrix-viewer :operator="operator2" />
   <h1>Another example</h1>
-  <matrix-viewer :operator-raw="operator3" />
+  <matrix-viewer :operator="operator3" />
   <h1>Sugar Solution</h1>
-  <matrix-viewer :operator-raw="opSugar" />
+  <matrix-viewer :operator="opSugar" />
   <h1>Mirror</h1>
-  <matrix-viewer :operator-raw="opMirror" />
+  <matrix-viewer :operator="opMirror" />
   <h1>CNOT gate</h1>
-  <matrix-viewer :operator-raw="opCNOT" />
+  <matrix-viewer :operator="opCNOT" />
   <h1>Toffoli gate</h1>
-  <matrix-viewer :operator-raw="opToffoli" />
+  <matrix-viewer :operator="opToffoli" />
 </template>
 <!-- eslint-disable-next-line vue-scoped-css/require-scoped -->
 <style lang="scss">


### PR DESCRIPTION
- ket-viewer is reative to `basis` change
- is reactive to `operator` change, with stable selection and permutation as long as operator dimension names match